### PR TITLE
Fixed an issue in sending blocks with huge data

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,14 +22,14 @@ A Java library to send automated test results as a notification to slack. All yo
 <dependency>
   <groupId>io.github.automationreddy</groupId>
   <artifactId>java-slack-notify</artifactId>
-  <version>1.1.0</version>
+  <version>1.1.1</version>
 </dependency>
 ```
 
 ### Gradle
 
 ```gradle
-implementation group: 'io.github.automationreddy', name: 'java-slack-notify', version: '1.1.0'
+implementation group: 'io.github.automationreddy', name: 'java-slack-notify', version: '1.1.1'
 ```
 
 ## Usage

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.github.automationreddy</groupId>
     <artifactId>java-slack-notify</artifactId>
-    <version>1.1.0</version>
+    <version>1.1.1</version>
 
     <name>Slack Notification for Test Results</name>
     <!-- FIXME change it to the project's website -->
@@ -53,6 +53,16 @@
             <artifactId>testng</artifactId>
             <version>7.4.0</version>
             <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>31.0.1-jre</version>
+        </dependency>
+        <dependency>
+            <groupId>commons-lang</groupId>
+            <artifactId>commons-lang</artifactId>
+            <version>2.6</version>
         </dependency>
     </dependencies>
     <distributionManagement>


### PR DESCRIPTION
### Slack payload per request has a limit to blocks and modals
- Added a utility which will split the list into chunks of size 50 and send them in a loop
